### PR TITLE
Feature/laravel stub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,15 @@ return Stencil::make()
     ->use('Illuminate\Database\Eloquent\Model')
     ->curlyStatement('class i_name extends Model', fn(Stencil $s) => $s
         ->line('use HasFactory;')
-    );
+    )
+    ->overrideStubLocation(base_path('Domain/Other/Path/i_name.php'));
 ```
+
+### Changing the stub output location
+
+In larger projects, you may not be using the default locations where Laravel generates the file. If you would like to change this,
+you can call the `overrideStubLocation` method on the Stencil, and provide a custom location where you would like the stub file to be written to.
+Note that this method is implemented via a macro, and code completion will not be available for it.
+
 
 If you have a formatter installed, such as Pint, PHP CS Fixer, or StyleCI, your stencil will be formatted as well!

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,5 @@ parameters:
         - src
     tmpDir: build/phpstan
     checkMissingIterableValueType: false
+    excludePaths:
+        - src/Laravel/LaravelCodeStencilServiceProvider.php

--- a/src/CodeStencilHelpers.php
+++ b/src/CodeStencilHelpers.php
@@ -26,7 +26,7 @@ trait CodeStencilHelpers
         return $this->foreach($lines, fn(self $s, string $line) => $s->line($line));
     }
 
-    public function phpdoc(string|array|null $summary = null, string|array|null $description = null, ?array $tags = null): static
+    public function phpdoc(string|array $summary = null, string|array $description = null, array $tags = null): static
     {
         if ($summary === null) {
             $summary = [];

--- a/src/CodeStencilHelpers.php
+++ b/src/CodeStencilHelpers.php
@@ -26,7 +26,7 @@ trait CodeStencilHelpers
         return $this->foreach($lines, fn(self $s, string $line) => $s->line($line));
     }
 
-    public function phpdoc(string|array $summary = null, string|array $description = null, array $tags = null): static
+    public function phpdoc(string|array|null $summary = null, string|array|null $description = null, ?array $tags = null): static
     {
         if ($summary === null) {
             $summary = [];

--- a/src/Laravel/LaravelCodeStencilServiceProvider.php
+++ b/src/Laravel/LaravelCodeStencilServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace CodeStencil\Laravel;
 
-use CodeStencil\Stencil;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Support\Facades\App;
@@ -15,6 +14,8 @@ use SplFileInfo;
 
 class LaravelCodeStencilServiceProvider extends ServiceProvider
 {
+    use RegistersOverrideStubLocationMacro;
+
     /**
      * Register services.
      */
@@ -63,14 +64,7 @@ class LaravelCodeStencilServiceProvider extends ServiceProvider
             });
         }
 
-        Stencil::macro('overrideStubLocation', function(string $path) {
-            $newPath = $this->substituteVariables($path);
-            $newPath = $this->applyFunctions($newPath);
-
-            $this->variable('overrideStubLocation', $newPath);
-
-            return $this;
-        });
+        $this->registerOverrideStubLocationMacro();
     }
 
     private function getFiles(): array

--- a/src/Laravel/RegistersOverrideStubLocationMacro.php
+++ b/src/Laravel/RegistersOverrideStubLocationMacro.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CodeStencil\Laravel;
+
+use CodeStencil\Stencil;
+
+trait RegistersOverrideStubLocationMacro
+{
+    private function registerOverrideStubLocationMacro(): void
+    {
+        Stencil::macro('overrideStubLocation', function(string $path) {
+            $newPath = $this->substituteVariables($path);
+            $newPath = $this->applyFunctions($newPath);
+
+            $this->variable('overrideStubLocation', $newPath);
+
+            return $this;
+        });
+    }
+}

--- a/src/Laravel/StencilFileProcessor.php
+++ b/src/Laravel/StencilFileProcessor.php
@@ -27,6 +27,27 @@ class StencilFileProcessor
 
         $stencil->variable($this->variables);
 
-        $stencil->save($this->path);
+        $savePath = $this->resolveSavePath($stencil);
+
+        $stencil->save($savePath);
+
+        if ($savePath != $this->path) {
+            unlink($this->path);
+        }
+    }
+
+    private function resolveSavePath(Stencil $stencil): string
+    {
+        $reflectionClass = new \ReflectionClass($stencil);
+        $prop            = $reflectionClass->getProperty('variables');
+        $prop->setAccessible(true);
+
+        $definedVariables = $prop->getValue($stencil);
+
+        if (array_key_exists('overrideStubLocation', $definedVariables)) {
+            return $definedVariables['overrideStubLocation'];
+        }
+
+        return $this->path;
     }
 }

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -3,10 +3,9 @@
 namespace CodeStencil;
 
 use Closure;
+use function CodeStencil\Utility\array_flatten;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-
-use function CodeStencil\Utility\array_flatten;
 
 class Stencil
 {
@@ -299,6 +298,10 @@ class Stencil
     protected function format(string $path): void
     {
         if ($this->isDryRun) {
+            return;
+        }
+
+        if (!$this->formattingEnabled) {
             return;
         }
 

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -3,17 +3,18 @@
 namespace CodeStencil;
 
 use Closure;
-use function CodeStencil\Utility\array_flatten;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+
+use function CodeStencil\Utility\array_flatten;
 
 class Stencil
 {
     use CodeStencilHelpers;
-    use FileHeaderStencil;
-    use Macroable;
     use Conditionable;
+    use FileHeaderStencil;
     use LaravelStringHelpers;
+    use Macroable;
 
     protected string $content = '';
 

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -3,9 +3,10 @@
 namespace CodeStencil;
 
 use Closure;
-use function CodeStencil\Utility\array_flatten;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+
+use function CodeStencil\Utility\array_flatten;
 
 class Stencil
 {

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -3,10 +3,9 @@
 namespace CodeStencil;
 
 use Closure;
+use function CodeStencil\Utility\array_flatten;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-
-use function CodeStencil\Utility\array_flatten;
 
 class Stencil
 {

--- a/tests/.pest/snapshots/StencilFileProcessorTest/process_file.snap
+++ b/tests/.pest/snapshots/StencilFileProcessorTest/process_file.snap
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class test extends Model
+{
+    use HasFactory;
+}

--- a/tests/.pest/snapshots/StencilFileProcessorTest/process_file.snap
+++ b/tests/.pest/snapshots/StencilFileProcessorTest/process_file.snap
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class test extends Model
-{
-    use HasFactory;
+class test extends Model{
+use HasFactory;
 }

--- a/tests/.pest/snapshots/StencilFileProcessorTest/process_file_custom_location.snap
+++ b/tests/.pest/snapshots/StencilFileProcessorTest/process_file_custom_location.snap
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class test extends Model
+{
+    use HasFactory;
+}

--- a/tests/.pest/snapshots/StencilFileProcessorTest/process_file_custom_location.snap
+++ b/tests/.pest/snapshots/StencilFileProcessorTest/process_file_custom_location.snap
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class test extends Model
-{
-    use HasFactory;
+class test extends Model{
+use HasFactory;
 }

--- a/tests/Fixtures/LaravelStub.php
+++ b/tests/Fixtures/LaravelStub.php
@@ -9,4 +9,5 @@ return Stencil::make()
     ->use('Illuminate\Database\Eloquent\Model')
     ->curlyStatement('class i_name extends Model', fn(Stencil $s) => $s
         ->line('use HasFactory;')
-    );
+    )
+    ->disableFormat();

--- a/tests/Fixtures/LaravelStub.php
+++ b/tests/Fixtures/LaravelStub.php
@@ -1,0 +1,12 @@
+<?php
+
+use CodeStencil\Stencil;
+
+return Stencil::make()
+    ->php()
+    ->namespace('App\Models')
+    ->use('Illuminate\Database\Eloquent\Factories\HasFactory')
+    ->use('Illuminate\Database\Eloquent\Model')
+    ->curlyStatement('class i_name extends Model', fn(Stencil $s) => $s
+        ->line('use HasFactory;')
+    );

--- a/tests/Fixtures/LaravelStubCustomLocation.php
+++ b/tests/Fixtures/LaravelStubCustomLocation.php
@@ -10,4 +10,5 @@ return Stencil::make()
     ->curlyStatement('class i_name extends Model', fn(Stencil $s) => $s
         ->line('use HasFactory;')
     )
+    ->disableFormat()
     ->overrideStubLocation(__DIR__ . DIRECTORY_SEPARATOR . 'Output.php');

--- a/tests/Fixtures/LaravelStubCustomLocation.php
+++ b/tests/Fixtures/LaravelStubCustomLocation.php
@@ -1,0 +1,13 @@
+<?php
+
+use CodeStencil\Stencil;
+
+return Stencil::make()
+    ->php()
+    ->namespace('App\Models')
+    ->use('Illuminate\Database\Eloquent\Factories\HasFactory')
+    ->use('Illuminate\Database\Eloquent\Model')
+    ->curlyStatement('class i_name extends Model', fn(Stencil $s) => $s
+        ->line('use HasFactory;')
+    )
+    ->overrideStubLocation(__DIR__ . DIRECTORY_SEPARATOR . 'Output.php');

--- a/tests/StencilFileProcessorTest.php
+++ b/tests/StencilFileProcessorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use CodeStencil\Laravel\RegistersOverrideStubLocationMacro;
+use CodeStencil\Laravel\StencilFileProcessor;
+
+uses(RegistersOverrideStubLocationMacro::class);
+
+test('process file', function() {
+    $realStubPath = __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'LaravelStub.php';
+    $tmpPath      = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'LaravelStub.php';
+    copy($realStubPath, $tmpPath);
+
+    (new StencilFileProcessor($tmpPath, ['i_name' => 'test']))();
+
+    $contents = file_get_contents($tmpPath);
+
+    expect($contents)->toMatchSnapshot();
+});
+
+test('process file custom location', function() {
+    $realStubPath = __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'LaravelStubCustomLocation.php';
+    $tmpDir       = sys_get_temp_dir();
+    $tmpPath      = $tmpDir . DIRECTORY_SEPARATOR . 'LaravelStubCustomLocation.php';
+    copy($realStubPath, $tmpPath);
+
+    $this->registerOverrideStubLocationMacro();
+
+    (new StencilFileProcessor($tmpPath, ['i_name' => 'test']))();
+
+    $contents = file_get_contents($tmpDir . DIRECTORY_SEPARATOR . 'Output.php');
+
+    expect($contents)->toMatchSnapshot();
+
+    expect(file_exists($tmpPath))->toBeFalse();
+});


### PR DESCRIPTION
When using Laravel, the existing stub files can return a `Stencil`. This this will then be processed and saved. Stub output locations can be changed by using the `overrideStubLocation` macro on the `Stencil` class.